### PR TITLE
Remove the build number from OpenAPI PRs.

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Update Open API
 
 on:
@@ -32,9 +29,9 @@ jobs:
             foxess-api.json
             src/v1.ts
           delete-branch: true
-          title: Update OpenAPI ${{ github.run_number }}
+          title: Update OpenAPI
           commit-message: |
             Update to the latest Open API specification.
           token: ${{ secrets.PAT }}
           committer: AutoHippo <auto@hippo.org>
-          branch: autohippo/openapi-update-${{ github.run_number }}
+          branch: autohippo/openapi-update


### PR DESCRIPTION
This will allow PRs to recreate instead of creating multiple each day.
