### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Potential fix for [https://github.com/teh-hippo/foxess-lib/security/code-scanning/8](https://github.com/teh-hippo/foxess-lib/security/code-scanning/8)

To fix the issue, we need to explicitly define the permissions for the `publish` job. Since the job involves publishing a package to npm and does not interact with GitHub features like pull requests or repository contents, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to perform the job.

The `permissions` block should be added at the job level for the `publish` job, as the `update-build-number` job already has its permissions explicitly defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
