### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,9 @@
 
 name: Audit
 
+permissions:
+  contents: read
+
 on:
   
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/teh-hippo/foxess-lib/security/code-scanning/6](https://github.com/teh-hippo/foxess-lib/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only installs dependencies and runs an audit, it does not require any write permissions. The `contents: read` permission is sufficient for these operations. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
