### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/teh-hippo/foxess-lib/security/code-scanning/5](https://github.com/teh-hippo/foxess-lib/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Based on the workflow's steps, the minimal required permission is `contents: read`, as the workflow primarily installs dependencies, builds, and tests the code without modifying repository contents or performing other privileged actions. This ensures the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
